### PR TITLE
Add agent instructions referencing design guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent Instructions
+
+The main design principles for this repository are documented in `design.md`.
+Before making code changes, read `design.md` to understand the architectural guidelines and maintain design consistency.

--- a/design.md
+++ b/design.md
@@ -1,0 +1,11 @@
+# Main Design Principles
+
+This project is a turn-based battle arena game built with Phaser 3 and Vite. The following principles guide development:
+
+- **Modularity**: Keep game logic in independent modules to simplify testing and future expansion.
+- **Separation of Concerns**: Core systems should be isolated from rendering and UI layers.
+- **Extensibility**: Use a plugin-friendly architecture so new features can be added without disrupting existing code.
+- **Maintainability**: Prioritize clear organization and readability across all source files.
+- **Testing**: Ensure that each component can be tested in isolation using Jest and Playwright.
+
+For detailed architecture and folder breakdowns, see `Design/Design.md`.


### PR DESCRIPTION
## Summary
- create `AGENTS.md` so the agent knows to consult `design.md`
- add a short `design.md` describing the main development principles

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68855ae2f8d0832c803798a4d273ff85